### PR TITLE
Implement interpolations

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -149,3 +149,33 @@ The `import` config option is an array of filenames that provides a way to merge
 
 The values in `import` can be anything accepted by PHP's `file_get_contents`, including but not limited to HTTP URLs and local file paths. A tilde at the start of a path is replaced with the path to the current user's home directory. Imports are fetched recursively (ie. imported configs can import further configs) with each unique path being fetched only the first time it appears.
 
+## Dynamic interpolated values
+
+The following tokens are recognized as dynamically interpolated values:
+
+<dl>
+<dt>%%branch%%
+    <dd>the branch that is being pushed from (`git symbolic-ref --short HEAD`)
+<dt>%%branch_pathsafe%%
+    <dd>same as %%branch%%, but changes each path separator to a hyphen
+<dt>%%commit%%
+    <dd>the commit hash being pushed up
+<dt>%%commit_abbrev%%
+    <dd>the abbreviated hash being pushed up
+<dt>%%user%%
+    <dd>the username of the user running the beam process (`id -un`)
+<dt>%%user_fullname%%
+    <dd>the full name of the user running the beam process (`id -F`)
+</dl>
+
+Sample configuration fragment:
+
+```json
+"servers": {
+    "live": {
+        "user": "operator",
+        "host": "www.example.com",
+        "webroot": "/usr/local/www/%%branch_pathsafe%%/shared/cached-copy",
+        "branch": "master"
+    },
+```


### PR DESCRIPTION
This enhancement enables one to specify interpolations that are to be
applied to any values that match the search element. The replacement can
be either a simple "replace", which uses str_replace to do simple string
substitution, or an "exec", which uses the output of a command for the
replacement.

The `interpolations` config option is an array of search & replace
values to interpolate into config values at runtime. For an example, see
this configuration fragment:

```json
"interpolations": [
	{
		"search": "%branch%",
		"exec": "git symbolic-ref --short HEAD"
	},
	{
		"search": "<#LIVESERVER#>",
		"replace": "www.example.com"
	}
],
"servers": {
	"dev": {
		"user": "operator",
		"host": "<#LIVESERVER#>",
		"webroot": "/usr/local/www/%branch%/shared/cached-copy"
	},
```

This would have the effect of making `beam up dev` use `www.example.com`
as the host, and `/usr/local/www/some-feature/shared/cached-copy` as the
webroot, if you happen to be working on a git branch named
"some-feature".

Interpolations are applied after any imports. This means that the import
paths are not subject to substitutions, but the values in the imported
files are subject to them.
