### PR TITLE
Refactor interpolations from #48 to use Beam's context

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -151,31 +151,32 @@ The values in `import` can be anything accepted by PHP's `file_get_contents`, in
 
 ## Dynamic interpolated values
 
-The following tokens are recognized as dynamically interpolated values:
-
-<dl>
-<dt>%%branch%%
-    <dd>the branch that is being pushed from (`git symbolic-ref --short HEAD`)
-<dt>%%branch_pathsafe%%
-    <dd>same as %%branch%%, but changes each path separator to a hyphen
-<dt>%%commit%%
-    <dd>the commit hash being pushed up
-<dt>%%commit_abbrev%%
-    <dd>the abbreviated hash being pushed up
-<dt>%%user%%
-    <dd>the username of the user running the beam process (`id -un`)
-<dt>%%user_fullname%%
-    <dd>the full name of the user running the beam process (`id -F`)
-</dl>
-
-Sample configuration fragment:
-
 ```json
-"servers": {
+"servers": [
     "live": {
-        "user": "operator",
+        "user": "%%username%%",
         "host": "www.example.com",
         "webroot": "/usr/local/www/%%branch_pathsafe%%/shared/cached-copy",
         "branch": "master"
     },
+]
 ```
+
+Beam offers some support for using dynamic values in configs by way of token replacement. The following tokens are recognized and will be replaced automatically in free-text config values where they are used:
+
+<dl>
+<dt>%%branch%%
+    <dd>The branch name that is being deployed. If a commit hash is passed to <code>--ref</code> on the command line, this is a best-guess of what the branch is, since a commit can be on multiple branches.
+<dt>%%branch_pathsafe%%
+    <dd>The same as <code>%%branch%%</code>, but changes each path separator to a hyphen
+<dt>%%commit%%
+    <dd>The commit hash being deployed
+<dt>%%commit_abbrev%%
+    <dd>The abbreviated hash being deployed
+<dt>%%target%%
+    <dd>The name of the server config being used for deployment.
+<dt>%%username%%
+    <dd>The username of the user running the beam process
+<dt>%%user_identity%%
+    <dd>The full name and email address of the current user according to the VCS. Eg. <code>Joe Smith &lt;joe.smith@example.com&gt;</code>
+</dl>

--- a/src/Heyday/Component/Beam/Beam.php
+++ b/src/Heyday/Component/Beam/Beam.php
@@ -741,7 +741,9 @@ class Beam
         $vcs = $this->options['vcsprovider'];
 
         if ($vcs instanceof GitLikeVcsProvider) {
-            $interpolator = new ValueInterpolator($vcs, $this->getOption('ref'));
+            $interpolator = new ValueInterpolator($vcs, $this->getOption('ref'), array(
+                'target' => $this->getOption('target')
+            ));
             return $interpolator->process($config);
         } else {
             throw new Exception('Config interpolation is only possible using a Git-like VCS');

--- a/src/Heyday/Component/Beam/Beam.php
+++ b/src/Heyday/Component/Beam/Beam.php
@@ -3,11 +3,14 @@
 namespace Heyday\Component\Beam;
 
 use Heyday\Component\Beam\Config\BeamConfiguration;
+use Heyday\Component\Beam\Config\ValueInterpolator;
 use Heyday\Component\Beam\DeploymentProvider\DeploymentProvider;
 use Heyday\Component\Beam\DeploymentProvider\DeploymentResult;
+use Heyday\Component\Beam\Exception\Exception;
 use Heyday\Component\Beam\Exception\InvalidArgumentException;
 use Heyday\Component\Beam\Exception\RuntimeException;
 use Heyday\Component\Beam\VcsProvider\Git;
+use Heyday\Component\Beam\VcsProvider\GitLikeVcsProvider;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\OptionsResolver\Options;
@@ -42,8 +45,12 @@ class Beam
         array $config,
         array $options
     ) {
+        // Perform initial setup and validation
         $this->config = $config;
         $this->setup($options);
+
+        // Apply variable interpolation config after initial checks
+        $this->config = $this->replaceConfigVariables($config);
     }
     /**
      * Uses the options resolver to set the options to the object from an array
@@ -721,6 +728,26 @@ class Beam
 
         return false;
     }
+
+    /**
+     * Replace variable placeholders in config fields
+     *
+     * @param array $config
+     * @return array
+     * @throws Exception
+     */
+    protected function replaceConfigVariables(array $config)
+    {
+        $vcs = $this->options['vcsprovider'];
+
+        if ($vcs instanceof GitLikeVcsProvider) {
+            $interpolator = new ValueInterpolator($vcs, $this->getOption('ref'));
+            return $interpolator->process($config);
+        } else {
+            throw new Exception('Config interpolation is only possible using a Git-like VCS');
+        }
+    }
+
     /**
      * This returns an options resolver that will ensure required options are set and that all options set are valid
      * @return OptionsResolver

--- a/src/Heyday/Component/Beam/Config/BeamConfiguration.php
+++ b/src/Heyday/Component/Beam/Config/BeamConfiguration.php
@@ -100,6 +100,7 @@ class BeamConfiguration extends Configuration implements ConfigurationInterface
             $configs
         );
     }
+
     /**
      * Load the contents of the files and URLs in $imports, recursively
      * @param array $imports - list of files/urls to load
@@ -148,27 +149,6 @@ class BeamConfiguration extends Configuration implements ConfigurationInterface
         }
 
         return $path;
-    }
-
-    /**
-     * Applies the specified interpolations to the fields of a config
-     * 
-     * @param array $config
-     */
-    protected function applyInterpolations(array &$config) {
-        $interpolations = array(
-            '%%branch%%' => function() { return exec('git symbolic-ref --short HEAD'); },
-            '%%branch_pathsafe%%' => function() { return str_replace(DIRECTORY_SEPARATOR, '-', exec('git symbolic-ref --short HEAD')); },
-            '%%commit%%' => function() { return exec('git rev-parse HEAD'); },
-            '%%commit_abbrev%%' => function() { return exec('git rev-parse --short HEAD'); },
-            '%%user%%' => function() { return exec('id -un'); },
-        );
-        array_walk_recursive($config, function(&$value, $key) use ($interpolations) {
-            foreach ($interpolations as $search => $replace_func) {
-                $value = str_replace($search, $replace_func(), $value);
-            }
-        });
-        return $config;
     }
 
     /**
@@ -260,7 +240,6 @@ class BeamConfiguration extends Configuration implements ConfigurationInterface
             ->validate()
                 ->always(
                     function ($v) use ($self) {
-                        $v = $self->applyInterpolations($v);
                         foreach ($v['commands'] as $commandName => $command) {
                             foreach ($command['servers'] as $server) {
                                 if (!isset($v['servers'][$server])) {

--- a/src/Heyday/Component/Beam/Config/ValueInterpolator.php
+++ b/src/Heyday/Component/Beam/Config/ValueInterpolator.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Heyday\Component\Beam\Config;
+
+use Heyday\Component\Beam\Exception\Exception;
+use Heyday\Component\Beam\VcsProvider\GitLikeVcsProvider;
+
+class ValueInterpolator
+{
+    /**
+     * @var GitLikeVcsProvider
+     */
+    protected $vcs;
+
+    /**
+     * Reference to use when retrieving information from the VCS
+     *
+     * @var string
+     */
+    protected $ref;
+
+    /**
+     * @param GitLikeVcsProvider $vcs
+     * @param string $vcsReference - commit reference to use when retrieving information from the VCS
+     * @throws Exception
+     */
+    public function __construct(GitLikeVcsProvider $vcs, $vcsReference)
+    {
+        $this->vcs = $vcs;
+        $this->ref = $vcsReference;
+    }
+
+    /**
+     * Apply interpolation (variable replacement) recursively to array values
+     *
+     * @param array $config
+     * @return array - array with variables replaced
+     */
+    public function process(array $config)
+    {
+        $interpolations = $this->getInterpolationsWithCaching();
+
+        array_walk_recursive($config, function(&$value, $key) use ($interpolations) {
+            foreach ($interpolations as $token => $replaceCallback) {
+                if (strpos($value, $token) !== false) {
+                    $value = str_replace($token, $replaceCallback(), $value);
+                }
+            }
+        });
+
+        return $config;
+    }
+
+    /**
+     * Return an array of callbacks to use with str_replace
+     *
+     * @return callable[]
+     */
+    protected function getInterpolations()
+    {
+        $vcs = $this->vcs;
+        $ref = $this->ref;
+
+        $interpolations = array(
+            '%%branch%%' => function() use ($vcs, $ref) {
+                return $vcs->getBranchForReference($ref);
+            },
+            '%%branch_pathsafe%%' => function() use ($vcs, $ref) {
+                $branch = $vcs->getBranchForReference($ref);
+                return str_replace(DIRECTORY_SEPARATOR, '-', $branch);
+            },
+            '%%commit%%' => function() use ($vcs, $ref) {
+                return $vcs->resolveReference($ref);
+            },
+            '%%commit_abbrev%%' => function() use ($vcs, $ref) {
+                return $vcs->resolveReference($ref, true);
+            },
+            '%%user_identity%%' => function() use ($vcs) {
+                return $vcs->getUserIdentity();
+            },
+            '%%username%%' => get_current_user(),
+        );
+
+        return $interpolations;
+    }
+
+    /**
+     * Return the results of self::getInterpolations wrapped in caching callbacks
+     *
+     * The first value returned for a token is cached so that multiple replacements do not
+     * generate the value multiple times (done using command-line programs, so it's slow-ish)
+     *
+     * @return callable[]
+     */
+    protected function getInterpolationsWithCaching()
+    {
+        $callbacks = array();
+        $cache = array();
+
+        foreach ($this->getInterpolations() as $token => $value) {
+            $callbacks[$token] = function() use ($token, $value, &$cache) {
+                if (is_callable($value)) {
+                    if (!array_key_exists($token, $cache)) {
+                        $cache[$token] = $value();
+                    }
+
+                    return $cache[$token];
+                }
+
+                return $value;
+            };
+        }
+
+        return $callbacks;
+    }
+}

--- a/src/Heyday/Component/Beam/Config/ValueInterpolator.php
+++ b/src/Heyday/Component/Beam/Config/ValueInterpolator.php
@@ -20,14 +20,22 @@ class ValueInterpolator
     protected $ref;
 
     /**
+     * Map of identifiers to replacement values
+     *
+     * @var array
+     */
+    protected $extraReplacements;
+
+    /**
      * @param GitLikeVcsProvider $vcs
      * @param string $vcsReference - commit reference to use when retrieving information from the VCS
-     * @throws Exception
+     * @param array $extraReplacements - array of tokens to provide replacement for
      */
-    public function __construct(GitLikeVcsProvider $vcs, $vcsReference)
+    public function __construct(GitLikeVcsProvider $vcs, $vcsReference, array $extraReplacements = array())
     {
         $this->vcs = $vcs;
         $this->ref = $vcsReference;
+        $this->extraReplacements = $extraReplacements;
     }
 
     /**
@@ -80,6 +88,10 @@ class ValueInterpolator
             },
             '%%username%%' => get_current_user(),
         );
+
+        foreach ($this->extraReplacements as $token => $value) {
+            $interpolations["%%$token%%"] = $value;
+        }
 
         return $interpolations;
     }

--- a/src/Heyday/Component/Beam/VcsProvider/Git.php
+++ b/src/Heyday/Component/Beam/VcsProvider/Git.php
@@ -11,7 +11,7 @@ use Symfony\Component\Process\Process;
  * Class Git
  * @package Heyday\Component\Beam\VcsProvider
  */
-class Git implements VcsProvider, GitLikeVcsProvider
+class Git implements GitLikeVcsProvider
 {
     /**
      * @var

--- a/src/Heyday/Component/Beam/VcsProvider/Git.php
+++ b/src/Heyday/Component/Beam/VcsProvider/Git.php
@@ -11,7 +11,7 @@ use Symfony\Component\Process\Process;
  * Class Git
  * @package Heyday\Component\Beam\VcsProvider
  */
-class Git implements VcsProvider
+class Git implements VcsProvider, GitLikeVcsProvider
 {
     /**
      * @var
@@ -203,5 +203,64 @@ class Git implements VcsProvider
             // fall back to using the current username.
             return $identity ? $identity : get_current_user();
         }
+    }
+
+    /**
+     * Return the commit hash for a given reference
+     *
+     * @param string $ref
+     * @param bool $abbreviated
+     * @return string - commit hash
+     * @throws RuntimeException
+     */
+    public function resolveReference($ref, $abbreviated = false)
+    {
+        if ($abbreviated) {
+            $command = 'git rev-parse --short %s';
+        } else {
+            $command = 'git rev-parse %s';
+        }
+
+        $process = $this->process(sprintf(
+            $command,
+            escapeshellarg($ref)
+        ));
+
+        return trim($process->getOutput());
+    }
+
+    /**
+     * Determine the branch a reference is on
+     *
+     * In the case multiple branches are returned, the current branch is preferred,
+     * otherwise the first returned by Git is used. This means the return value of
+     * this function is a bit of a guess.
+     *
+     * @param string $ref
+     * @return string - branch name
+     */
+    public function getBranchForReference($ref)
+    {
+        $process = $this->process(sprintf(
+            'git branch --contains %s -a',
+            escapeshellarg($ref)
+        ));
+
+        $lines = explode("\n", trim($process->getOutput()));
+
+        foreach ($lines as $index => $line) {
+            // Prefer the current branch
+            if (strpos($line, '*') === 0) {
+                $branch = $line;
+                break;
+            }
+
+            // Default to the first line if there's no current branch returned
+            if ($index === 0) {
+                $branch = $line;
+            }
+        }
+
+        return ltrim($branch, '* ');
     }
 }

--- a/src/Heyday/Component/Beam/VcsProvider/GitLikeVcsProvider.php
+++ b/src/Heyday/Component/Beam/VcsProvider/GitLikeVcsProvider.php
@@ -4,7 +4,7 @@
 namespace Heyday\Component\Beam\VcsProvider;
 
 
-interface GitLikeVcsProvider
+interface GitLikeVcsProvider extends VcsProvider
 {
     /**
      * Return the commit hash for a given reference

--- a/src/Heyday/Component/Beam/VcsProvider/GitLikeVcsProvider.php
+++ b/src/Heyday/Component/Beam/VcsProvider/GitLikeVcsProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+
+namespace Heyday\Component\Beam\VcsProvider;
+
+
+interface GitLikeVcsProvider
+{
+    /**
+     * Return the commit hash for a given reference
+     *
+     * @param string $ref
+     * @param bool $abbreviated
+     * @return string - commit hash
+     */
+    public function resolveReference($ref, $abbreviated = false);
+
+    /**
+     * Determine the branch a reference is on
+     *
+     * @param string $ref
+     * @return string - branch name
+     */
+    public function getBranchForReference($ref);
+
+    /**
+     * Get the identity of a user as defined in the VCS config
+     *
+     * This is the name that the VCS uses to identify a user in commits.
+     * Output should be in the format:
+     *
+     *     John Doe <john.doe@example.com>
+     *
+     * @return string
+     */
+    public function getUserIdentity();
+}

--- a/tests/Heyday/Component/Beam/BeamTest.php
+++ b/tests/Heyday/Component/Beam/BeamTest.php
@@ -46,7 +46,7 @@ class BeamTest extends \PHPUnit_Framework_TestCase
      */
     protected function getVcsProviderStub($exists = true, $available = array('master'), $current = 'master')
     {
-        $vcsProviderStub = $this->getMock('Heyday\Component\Beam\VcsProvider\VcsProvider');
+        $vcsProviderStub = $this->getMock('Heyday\Component\Beam\VcsProvider\GitLikeVcsProvider');
         $vcsProviderStub->expects($this->any())
             ->method('getCurrentBranch')
             ->will($this->returnValue($current));


### PR DESCRIPTION
This refactors #48 to use internal state to inform values, rather than directly calling Git commands when initialising the config. This means that the deployment context (eg. `--ref`) is correctly applied to config value replacements.