### PR TITLE
Replace custom json_encode implementation with PHP 5.4 json options

### DIFF
--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -66,81 +66,12 @@ class InitCommand extends SymfonyCommand
         );
 
         // Save template
-        file_put_contents('beam.json', str_replace('\/', '/', $this->jSONFormat(json_encode($template))));
+        file_put_contents('beam.json', json_encode($template, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 
         $output->writeln(
             "<info>Success: beam.json file saved to " . getcwd() .
             "/beam.json - be sure to check the file before using it</info>"
         );
 
-    }
-
-    /**
-     * @param $json
-     * @return bool|string
-     */
-    private function jSONFormat($json)
-    {
-        $tab = "\t";
-        $new_json = "";
-        $indent_level = 0;
-        $in_string = false;
-
-        $json_obj = json_decode($json);
-
-        if ($json_obj === false) {
-            return false;
-        }
-
-        $json = json_encode($json_obj);
-        $len = strlen($json);
-
-        for ($c = 0; $c < $len; $c++) {
-            $char = $json[$c];
-            switch ($char) {
-                case '{':
-                case '[':
-                    if (!$in_string) {
-                        $new_json .= $char . "\n" . str_repeat($tab, $indent_level + 1);
-                        $indent_level++;
-                    } else {
-                        $new_json .= $char;
-                    }
-                    break;
-                case '}':
-                case ']':
-                    if (!$in_string) {
-                        $indent_level--;
-                        $new_json .= "\n" . str_repeat($tab, $indent_level) . $char;
-                    } else {
-                        $new_json .= $char;
-                    }
-                    break;
-                case ',':
-                    if (!$in_string) {
-                        $new_json .= ",\n" . str_repeat($tab, $indent_level);
-                    } else {
-                        $new_json .= $char;
-                    }
-                    break;
-                case ':':
-                    if (!$in_string) {
-                        $new_json .= ": ";
-                    } else {
-                        $new_json .= $char;
-                    }
-                    break;
-                case '"':
-                    if ($c > 0 && $json[$c - 1] != '\\') {
-                        $in_string = !$in_string;
-                    }
-                // Fall through
-                default:
-                    $new_json .= $char;
-                    break;
-            }
-        }
-
-        return $new_json;
     }
 }


### PR DESCRIPTION
Options to pretty-print and output JSON without escaped slashes have been
available since PHP 5.4. Beam doesn't currently define a minimum PHP version, though I think we still technically support PHP 5.3 (as in, it will probably work).

Is anyone still using Beam on ancient versions of PHP that has an opinion on this? Otherwise I'd say at least PHP 5.5 as a minimum going forward.

Symfony Console `3.x` has a minimum PHP version requirement of 5.5.9. I haven't checked if `2.x` is compatible with PHP `7.x` yet, but that's likely the deciding factor for our minimum version.