### PR TITLE
Add "syncPermissions" config option for Rsync

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -77,6 +77,7 @@ When `type` is set to 'ftp' or 'sftp', a number of FTP specific properties are a
 ### Rsync properties
 
  * `sshpass` *(boolean: false)* - Use the program [`sshpass`](http://sourceforge.net/projects/sshpass/) to enter your SSH password automatically when using password authentication. With this option enabled, Beam will prompt for an SSH password once instead of an SSH client prompting for each new connection. Key-based authentication is reccommeded, though this may not suit everyone. To use this option you will need to have the `sshpass` program accessible on your path.
+ * `syncPermissions` *(boolean: true)* - Sync permissions (file mode) of transferred files and directories. Set this to `false` to let the target filesystem control file mode. This is on by default for backwards compatibility.
 
 
 ## Exclude

--- a/src/Config/BeamConfiguration.php
+++ b/src/Config/BeamConfiguration.php
@@ -324,6 +324,7 @@ class BeamConfiguration extends Configuration implements ConfigurationInterface
                         ->scalarNode('ssl')->defaultFalse()->end();
                 }
                 break;
+
             case 'rsync':
                 $node->scalarNode('webroot')
                     ->isRequired()
@@ -335,6 +336,7 @@ class BeamConfiguration extends Configuration implements ConfigurationInterface
                         )->end()
                         ->end()
                     ->scalarNode('user')->end()
+                    ->scalarNode('syncPermissions')->defaultTrue()->end()
                     ->scalarNode('sshpass')->defaultFalse()->end();
                 break;
         }

--- a/src/DeploymentProvider/Rsync.php
+++ b/src/DeploymentProvider/Rsync.php
@@ -166,7 +166,9 @@ class Rsync extends Deployment implements DeploymentProvider, ResultStream
      */
     protected function buildCommand($fromPath, $toPath, $dryrun = false)
     {
-        $flags = 'rlpD'; // recursion, links, perms, devices, specials
+        $server = $this->beam->getServer();
+
+        $flags = 'rlD'; // recursion, links, devices, specials
 
         $command = array(
             array(
@@ -177,6 +179,11 @@ class Rsync extends Deployment implements DeploymentProvider, ResultStream
             '-' . $flags,
             '--itemize-changes'
         );
+
+        // Sync permissions if enabled for the target
+        if ($server['syncPermissions']) {
+            $command[] = '--perms';
+        }
         
         if ($this->options['args'] !== '') {
             $command[] = $this->options['args'];

--- a/tests/Heyday/Beam/Config/BeamConfigurationTest.php
+++ b/tests/Heyday/Beam/Config/BeamConfigurationTest.php
@@ -41,7 +41,8 @@ class BeamConfigurationTest extends \PHPUnit_Framework_TestCase
                             'user' => 'test',
                             'host' => 'test',
                             'webroot' => 'test',
-                            'branch' => 'test'
+                            'branch' => 'test',
+                            'syncPermissions' => false,
                         )
                     )
                 )
@@ -82,7 +83,8 @@ class BeamConfigurationTest extends \PHPUnit_Framework_TestCase
                     'webroot' => 'test',
                     'branch' => 'test',
                     'type' => 'rsync',
-                    'sshpass' => false
+                    'sshpass' => false,
+                    'syncPermissions' => false,
                 )
             ),
             $processedConfig['servers']
@@ -118,7 +120,8 @@ class BeamConfigurationTest extends \PHPUnit_Framework_TestCase
                         'host' => 'test',
                         'webroot' => 'test',
                         'type' => 'rsync',
-                        'sshpass' => false
+                        'sshpass' => false,
+                        'syncPermissions' => true
                     )
                 ),
                 'import' => array(),
@@ -283,7 +286,8 @@ class BeamConfigurationTest extends \PHPUnit_Framework_TestCase
                         'webroot' => 'test',
                         'branch' => 'test',
                         'type' => 'rsync',
-                        'sshpass' => false
+                        'sshpass' => false,
+                        'syncPermissions' => true,
                     )
                 )
             ),

--- a/tests/Heyday/Beam/DeploymentProvider/RsyncTest.php
+++ b/tests/Heyday/Beam/DeploymentProvider/RsyncTest.php
@@ -621,10 +621,20 @@ OUTPUT
                 $this->returnValue(false)
             );
 
+        $server = array(
+            'syncPermissions' => false
+        );
+
+        $beamMock->method('getServer')->will(
+            $this->returnCallback(function() use (&$server) {
+                return $server;
+            })
+        );
+
         $rsync->setBeam($beamMock);
 
         $this->assertEquals(
-            'rsync /testfrom/ /testto -rlpD --itemize-changes --checksum --compress --delay-updates --exclude-from="/test"',
+            'rsync /testfrom/ /testto -rlD --itemize-changes --checksum --compress --delay-updates --exclude-from="/test"',
             $this->getAccessibleMethod('buildCommand')->invoke(
                 $rsync,
                 '/testfrom',
@@ -632,8 +642,10 @@ OUTPUT
             )
         );
 
+        $server['syncPermissions'] = true;
+
         $this->assertEquals(
-            'rsync /testfrom/ /testto -rlpD --itemize-changes --dry-run --checksum --compress --delay-updates --exclude-from="/test"',
+            'rsync /testfrom/ /testto -rlD --itemize-changes --perms --dry-run --checksum --compress --delay-updates --exclude-from="/test"',
             $this->getAccessibleMethod('buildCommand')->invoke(
                 $rsync,
                 '/testfrom',
@@ -641,6 +653,8 @@ OUTPUT
                 true
             )
         );
+
+        $server['syncPermissions'] = false;
 
         // Pretend to be an old version of rsync to output pre-3.0.1 compatible options
         $rsync = $this->getRsyncMock(
@@ -662,7 +676,7 @@ OUTPUT
         $rsync->method('getRsyncVersion')->willReturn('2.6.0');
 
         $this->assertEquals(
-            'rsync /testfrom/ /testto -rlpD --itemize-changes --checksum --delete --compress --delay-updates --delete-after --exclude-from="/test"',
+            'rsync /testfrom/ /testto -rlD --itemize-changes --checksum --delete --compress --delay-updates --delete-after --exclude-from="/test"',
             $this->getAccessibleMethod('buildCommand')->invoke(
                 $rsync,
                 '/testfrom',
@@ -686,7 +700,7 @@ OUTPUT
         $rsync->setBeam($beamMock);
 
         $this->assertEquals(
-            'rsync /testfrom/ /testto -rlpD --itemize-changes --checksum --delete --compress --delay-updates --delete-delay --exclude-from="/test"',
+            'rsync /testfrom/ /testto -rlD --itemize-changes --checksum --delete --compress --delay-updates --delete-delay --exclude-from="/test"',
             $this->getAccessibleMethod('buildCommand')->invoke(
                 $rsync,
                 '/testfrom',


### PR DESCRIPTION
It's not always desirable to sync file permissions. We've come across this quite a few times and worked around with `--args='--no-p'`, but it looks like this will be useful to have in `beam.json`.

Defaults to true to maintain the existing behaviour.

Resolves #53